### PR TITLE
docs: update file operation guidelines link

### DIFF
--- a/.roo/rules/tool_guidelines_index.md
+++ b/.roo/rules/tool_guidelines_index.md
@@ -3,15 +3,15 @@
 To prevent common errors when using tools, refer to these detailed guidelines:
 
 ## File Operations
-- [File Operations Guidelines](.roo/rules-code/file_operations.md) - Guidelines for read_file, write_to_file, and list_files
+- [File Operations Guidelines](./../rules-code/file_operations_guidelines.md) - Guidelines for read_file, write_to_file, and list_files
 
 ## Code Editing
-- [Code Editing Guidelines](.roo/rules-code/code_editing.md) - Guidelines for apply_diff
-- [Search and Replace Guidelines](.roo/rules-code/search_replace.md) - Guidelines for search_and_replace
-- [Insert Content Guidelines](.roo/rules-code/insert_content.md) - Guidelines for insert_content
+- [Code Editing Guidelines](./../rules-code/code_editing.md) - Guidelines for apply_diff
+- [Search and Replace Guidelines](./../rules-code/search_replace.md) - Guidelines for search_and_replace
+- [Insert Content Guidelines](./../rules-code/insert_content.md) - Guidelines for insert_content
 
 ## Common Error Prevention
-- [apply_diff Error Prevention](.roo/rules-code/apply_diff_guidelines.md) - Specific guidelines to prevent errors with apply_diff
+- [apply_diff Error Prevention](./../rules-code/apply_diff_guidelines.md) - Specific guidelines to prevent errors with apply_diff
 
 ## Key Points to Remember:
 1. Always include all required parameters for each tool


### PR DESCRIPTION
Fixes broken link to file operation guidelines.

Updates the relative path to point to the correct location of the file_operations_guidelines.md file.