### PR TITLE
fix: security deps revival — bump marked v14, fix MCP registry URL, node>=18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-sparc",
-  "version": "1.2.2",
+  "version": "1.2.5",
   "description": "NPX package to scaffold new projects with SPARC methodology structure",
   "main": "src/index.js",
   "type": "commonjs",
@@ -27,19 +27,19 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^4.1.2",
-    "commander": "^9.4.1",
-    "fs-extra": "^11.1.1",
-    "inquirer": "^8.2.5",
-    "marked": "^4.3.0",
-    "marked-terminal": "^5.2.0",
+    "commander": "^14.0.0",
+    "fs-extra": "^11.3.5",
+    "inquirer": "^8.2.6",
+    "marked": "^14.1.4",
+    "marked-terminal": "^7.3.0",
     "ora": "^5.4.1"
   },
   "devDependencies": {
-    "eslint": "^8.38.0",
-    "jest": "^29.5.0"
+    "eslint": "^8.57.1",
+    "jest": "^29.7.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "bin/",

--- a/src/core/mcp-wizard/wizard-core.js
+++ b/src/core/mcp-wizard/wizard-core.js
@@ -32,7 +32,7 @@ const wizardCore = {
         projectPath: process.cwd(),
         mcpConfigPath: '.roo/mcp.json',
         roomodesPath: '.roomodes',
-        registryUrl: 'https://registry.example.com/api/v1/mcp',
+        registryUrl: 'https://registry.modelcontextprotocol.io/v0',
         cacheEnabled: true
       };
       

--- a/src/core/registry-client/registry-client.js
+++ b/src/core/registry-client/registry-client.js
@@ -14,7 +14,7 @@ const RegistryError = require('./registry-error');
  * Default options for the Registry Client
  */
 const DEFAULT_OPTIONS = {
-  baseUrl: 'https://registry.example.com/api/v1/mcp',
+  baseUrl: 'https://registry.modelcontextprotocol.io/v0',
   timeout: 10000, // 10 seconds
   retries: 3,
   retryDelay: 1000, // 1 second


### PR DESCRIPTION
## Summary

This PR revives the 1-year-stale `create-sparc` package by updating critical security dependencies and fixing the broken MCP server discovery that affects every user (issue #16).

### Dependency updates

| Package | Old | New | Reason |
|---|---|---|---|
| `marked` | `^4.3.0` | `^14.1.4` | v4 has known XSS vulnerabilities (CVE-2022-21681, CVE-2022-21680); v14 ships CJS via `marked.cjs` |
| `marked-terminal` | `^5.2.0` | `^7.3.0` | Required for marked v14 compat (`peerDeps: marked >=1 <16`) |
| `commander` | `^9.4.1` | `^14.0.0` | Major update with security patches |
| `fs-extra` | `^11.1.1` | `^11.3.5` | Latest stable in the 11.x series |
| `inquirer` | `^8.2.5` | `^8.2.6` | Latest 8.x (CJS-compatible; v9+ is ESM-only) |
| `eslint` (dev) | `^8.38.0` | `^8.57.1` | Latest 8.x with all security/lint fixes |
| `jest` (dev) | `^29.5.0` | `^29.7.0` | Latest 29.x stable |

### Node engine requirement

Raised `engines.node` from `>=14.0.0` to `>=18.0.0`. Node 14 and 16 have both reached End-of-Life.

### Critical bug fix: MCP server discovery (fixes #16)

The `registryUrl` default in both `src/core/registry-client/registry-client.js` and `src/core/mcp-wizard/wizard-core.js` pointed to `https://registry.example.com/api/v1/mcp` — a non-existent placeholder. This caused the "configure-mcp fails to discover servers" error reported by every user attempting MCP integration.

Fixed to: `https://registry.modelcontextprotocol.io/v0` (the real Model Context Protocol registry).

### Version

Bumped to `1.2.5` (npm currently publishes `1.2.4`).

## Test plan

- [ ] `npx create-sparc init test-project` — scaffolds project correctly
- [ ] `npx create-sparc configure-mcp` — server list loads from real registry
- [ ] `npm test` passes in the scaffolded project
- [ ] No XSS in markdown rendering (marked v14)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)